### PR TITLE
Tokio spawn the message handler

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, sync::Arc};
 
 use action::add_to_qbit;
 use irc::client::prelude::*;
@@ -31,16 +31,16 @@ async fn main() -> Result<(), failure::Error> {
     let tl = trackers::torrentleech::TorrentleechTracker::new(&env::var("TL_RSS_KEY").unwrap());
     let ipt = trackers::ipt::IptTracker::new(&env::var("IPT_PASSKEY").unwrap());
 
-    let filter = filters::Filter{
+    let filter = Arc::new(filters::Filter{
         valid_regexes: RegexSet::new(&cfg.valid_regexes).unwrap(),
         size_max: cfg.max_size,
-    };
+    });
 
     // let tl_t = tokio::spawn(async move {
     //     tl.monitor(&filter).await;
     // });
     let ipt_t = tokio::spawn(async move {
-        ipt.monitor(&filter).await;
+        ipt.monitor(filter).await;
     });
 
     // join!(tl_t, ipt_t);

--- a/src/trackers/ipt.rs
+++ b/src/trackers/ipt.rs
@@ -59,30 +59,7 @@ impl super::Tracker for IptTracker {
     // Althought not visible in the "string", IRC formatting means there are control characters beteen e.g. the "-" and "4" (e.g. 0x03)
     // so we cant use e.g find("-4")
     async fn parse_message(&self, msg: &str) -> Option<Self::Torrent> {
-        trace!("parse_message for {} ({:2X?})", msg, msg.as_bytes());
-
-        let name_start_index = msg.find("]")? + 5;
-
-        // First check if we can find FREELEECH, if not then normal ending
-        let (name_end_index, freeleech, https_index) = match msg.find("4FREELEECH - https") {
-            Some(pos) => (pos-2, true, pos + 13),
-            None => {
-                let pos = msg.find("https://www.iptorrents")?;
-                (pos - 4, false, pos)
-            }
-        };
-
-        let size_index = https_index + msg[https_index..].find(" ")? + 5;
-        let name = msg[name_start_index..name_end_index].to_owned(); // This is name WITH spaces
-        let torrent_id = msg[https_index+42..size_index-5].to_owned();
-        let size = msg[size_index..].to_owned();
-
-        Some(IptTorrent{
-            name,
-            id: torrent_id,
-            freeleech,
-            size,
-        })
+        todo!()
     }
 
     async fn download(&self, torrent: Self::Torrent) -> Result<std::ffi::OsString, failure::Error> {
@@ -136,39 +113,105 @@ impl super::Tracker for IptTracker {
         info!("Connected");
 
         while let Some(message) = stream.next().await.transpose()? {
-            match message.command {
-                Command::PRIVMSG(_, p2) => {
-                    debug!("Got message: {}", p2);
-                    if let Some(x) = self.parse_message(&p2).await {
-                        debug!("Got new release: {:?}", x);
+            let passkey = self.passkey.to_owned();
+            let filter = filter.clone();
+            tokio::spawn(async move{
+                match message.command {
+                    Command::PRIVMSG(_, p2) => {
+                        debug!("Got message: {}", p2);
+                        if let Some(x) = parse_message(&p2).await {
+                            debug!("Got new release: {:?}", x);
 
-                        if filter.check(x.clone()) == true {
-                            debug!("Passed filter, we should get it");
+                            if filter.check(x.clone()) == true {
+                                debug!("Passed filter, we should get it");
 
-                            match self.download(x.clone()).await {
-                                Ok(p) => {
-                                    debug!("Downloaded to {:?}", &p);
-                                    add_to_qbit_v2(&p);
-                                },
-                                Err(e) => {
-                                    error!("Failed to download: {}", e)
+                                match download_torrent(&passkey, x.clone()).await {
+                                    Ok(p) => {
+                                        debug!("Downloaded to {:?}", &p);
+                                        add_to_qbit_v2(&p);
+                                    },
+                                    Err(e) => {
+                                        error!("Failed to download: {}", e)
+                                    }
                                 }
+                            } else {
+                                debug!("Did not pass filter");
                             }
-                        } else {
-                            debug!("Did not pass filter");
-                        }
 
-                        
-                    } else {
-                        error!("Failed to parse message: {}", p2);
+                            
+                        } else {
+                            error!("Failed to parse message: {}", p2);
+                        }
+                    },
+                    _ => {
+                        // noop
                     }
-                },
-                _ => {
-                    // noop
                 }
-            }
+            });
         }
 
         Ok(())
+    }
+}
+
+async fn parse_message(msg: &str) -> Option<IptTorrent> {
+    trace!("parse_message for {} ({:2X?})", msg, msg.as_bytes());
+
+    let name_start_index = msg.find("]")? + 5;
+
+    // First check if we can find FREELEECH, if not then normal ending
+    let (name_end_index, freeleech, https_index) = match msg.find("4FREELEECH - https") {
+        Some(pos) => (pos-2, true, pos + 13),
+        None => {
+            let pos = msg.find("https://www.iptorrents")?;
+            (pos - 4, false, pos)
+        }
+    };
+
+    let size_index = https_index + msg[https_index..].find(" ")? + 5;
+    let name = msg[name_start_index..name_end_index].to_owned(); // This is name WITH spaces
+    let torrent_id = msg[https_index+42..size_index-5].to_owned();
+    let size = msg[size_index..].to_owned();
+
+    Some(IptTorrent{
+        name,
+        id: torrent_id,
+        freeleech,
+        size,
+    })
+}
+
+
+async fn download_torrent(passkey: &str, torrent: IptTorrent) -> Result<std::ffi::OsString, failure::Error> {
+    let download_url = format!("https://iptorrents.com/download.php/{}/{}.torrent?torrent_pass={}", torrent.id, torrent.name, passkey);
+
+    trace!("Going to download torrent from {}", download_url);
+    let res = reqwest::get(download_url).await;
+
+    let response = match res {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Got error from HTTP request: {}", e);
+            return Err(e.into());
+        }
+    };
+
+    trace!("Got HTTP {} from IPT", response.status());
+    let bytes = response.bytes().await.unwrap();
+
+    // No need to bencode-decode here...
+    let filename = format!("{}.torrent", torrent.name);
+    let p = temp_dir().as_path().join(&filename);
+    let mut f = std::fs::File::create(&p).unwrap();
+    
+    match f.write_all(&bytes) {
+        Ok(_) => {
+            debug!("wrote to file {}", filename);
+            return Ok(p.into_os_string());
+        },
+        Err(e) => {
+            error!("fail to write to file; {}", e);
+            return Err(e.into());
+        }
     }
 }

--- a/src/trackers/ipt.rs
+++ b/src/trackers/ipt.rs
@@ -1,4 +1,4 @@
-use std::{env::temp_dir, fmt::format, io::Write};
+use std::{env::temp_dir, fmt::format, io::Write, sync::Arc};
 
 use futures::StreamExt;
 use irc::{client::{data::Config, Client}, proto::Command};
@@ -6,6 +6,7 @@ use log::{debug, error, info, trace};
 
 use crate::{action::{add_to_qbit, add_to_qbit_v2}, filters};
 
+#[derive(Clone)]
 pub struct IptTracker {
     passkey: String,
 }
@@ -118,7 +119,7 @@ impl super::Tracker for IptTracker {
         }
     }
 
-    async fn monitor(&self, filter: &filters::Filter) -> Result<(), failure::Error> {
+    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error> {
         let config = Config{
             nickname: Some("snatcherdev_bot".to_owned()),
             server: Some("irc.iptorrents.com".to_owned()),

--- a/src/trackers/mod.rs
+++ b/src/trackers/mod.rs
@@ -1,4 +1,4 @@
-use std::ffi::{OsStr, OsString};
+use std::{ffi::{OsStr, OsString}, sync::Arc};
 
 use crate::filters;
 
@@ -14,7 +14,7 @@ pub trait Torrent: std::fmt::Debug {
 pub trait Tracker {
     type Torrent: Torrent;
 
-    async fn monitor(&self, filter: &filters::Filter) -> Result<(), failure::Error>;
+    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error>;
     async fn parse_message(&self, msg: &str) -> Option<Self::Torrent>;
     async fn download(&self, torrent: Self::Torrent) -> Result<OsString, failure::Error>;
 }

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -1,4 +1,4 @@
-use std::{env::temp_dir, ffi::{OsStr, OsString}, io::Write};
+use std::{env::temp_dir, ffi::{OsStr, OsString}, io::Write, sync::Arc};
 
 use futures::StreamExt;
 use irc::{client::{data::Config, Client}, proto::Command};
@@ -68,71 +68,10 @@ impl super::Tracker for TorrentleechTracker {
     }
 
     async fn parse_message(&self, msg: &str) -> Option<Self::Torrent> {
-        trace!("parse_message for {} ({:2X?})", msg, msg.as_bytes());
-
-        let name_start_index = msg.find("Name:'")?;
-        let name_end_index = msg.find("' uploaded by '")?;
-        let (uploader_end_index, freeleech, lenn) = match msg.find("' - ") {
-            Some(pos) => (pos, false, 11),
-            None => {
-                match msg.find("' freeleech - ") {
-                    Some(pos) => (pos, true, 21),
-                    None => return None
-                }
-            }
-        };
-
-        let name_original: String = msg[name_start_index+6..name_end_index].to_owned();
-        let name_dot = name_original.replace(" ", ".");
-        let url: String = msg[uploader_end_index+lenn..].to_owned();
-
-        let id_index = url.rfind("/")?;
-        let id: String = url[id_index+1..].to_owned();
-
-        let download_url = format!("https://www.torrentleech.org/rss/download/{}/{}/{}.torrent", id, self.rss_key, name_dot);
-
-        trace!("Going to download torrent from {}", download_url);
-        let res = reqwest::get(download_url).await;
-
-        let response = match res {
-            Ok(v) => v,
-            Err(e) => {
-                error!("Got error from HTTP request: {}", e);
-                return None;
-            }
-        };
-
-        trace!("Got HTTP {} from TL", response.status());
-        let bytes = response.bytes().await.unwrap();
-
-        // Try and parse torrent
-        trace!("Going to bencode-decode torrent");
-        let t = match de::from_bytes::<torrent::Torrent>(&bytes) {
-            Ok(t) => {
-                trace!("Parsed torrent, got {:?}", t);
-                t
-            },
-            Err(e) => {
-                error!("Error bencode-decoding torrent: {}", e);
-                return None;
-            }
-        };
-
-        return Some(TorrentleechTorrent{
-            name: name_dot,
-            uploader: msg[name_end_index+15..uploader_end_index].to_owned(),
-            url,
-            freeleech,
-            id,
-            raw_torrent: bytes.to_vec(),
-            // path: p.into(),
-            size: t.size(),
-        });
+        todo!()
     }
 
-
-
-    async fn monitor(&self, filter: &filters::Filter) -> Result<(), failure::Error> {
+    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error> {
         let config = Config {
             nickname: Some("snatcherdev_bot".to_owned()),
             server: Some("irc.torrentleech.org".to_owned()),
@@ -148,34 +87,95 @@ impl super::Tracker for TorrentleechTracker {
         info!("Connected");
         // let x = trackers::torrentleech::TorrentleechTracker{};
         // let tl = trackers::torrentleech::TorrentleechTracker::new(&env::var("TL_RSS_KEY").unwrap());
-    
+        // let f = filter.clone();
+
     
         while let Some(message) = stream.next().await.transpose()? {
-            match message.command {
-                Command::PRIVMSG(p1, p2) => {
-                    let x = self.parse_message(&p2).await;
-                    if let Some(x) = x {
-                        debug!("Got new release: {:?}", x);
+            let rss_key = self.rss_key.to_owned();
+            let filter = filter.clone();
 
-                        if filter.check(x) == true {
-                            debug!("Passed filter, we should get it");
-                        } else {
-                            debug!("Did not pass filter");
+            tokio::spawn(async move {
+                match message.command {
+                    Command::PRIVMSG(_, p2) => {
+                        let x = parse_message(&rss_key, &p2).await;
+                        if let Some(x) = x {
+                            debug!("Got new release: {:?}", x);
+
+                            if filter.check(x) == true {
+
+                            }
                         }
-                        
-                        // TODO:
-                        // Call download
-                        // Call add_to_qbit
-                    } else {
-                        error!("Failed to parse message: {}", p2);
+                    },
+                    _ => {
+                        debug!("Got something we don't handle")
                     }
-                },
-                other => {
-                    // println!("got something else: {:?}", other)
                 }
-            }
+            });
         }
     
         Ok(())
     }
+}
+
+async fn parse_message(rss_key: &str, msg: &str) -> Option<TorrentleechTorrent> {
+    trace!("parse_message for {} ({:2X?})", msg, msg.as_bytes());
+
+    let name_start_index = msg.find("Name:'")?;
+    let name_end_index = msg.find("' uploaded by '")?;
+    let (uploader_end_index, freeleech, lenn) = match msg.find("' - ") {
+        Some(pos) => (pos, false, 11),
+        None => {
+            match msg.find("' freeleech - ") {
+                Some(pos) => (pos, true, 21),
+                None => return None
+            }
+        }
+    };
+
+    let name_original: String = msg[name_start_index+6..name_end_index].to_owned();
+    let name_dot = name_original.replace(" ", ".");
+    let url: String = msg[uploader_end_index+lenn..].to_owned();
+
+    let id_index = url.rfind("/")?;
+    let id: String = url[id_index+1..].to_owned();
+
+    let download_url = format!("https://www.torrentleech.org/rss/download/{}/{}/{}.torrent", id, rss_key, name_dot);
+
+    trace!("Going to download torrent from {}", download_url);
+    let res = reqwest::get(download_url).await;
+
+    let response = match res {
+        Ok(v) => v,
+        Err(e) => {
+            error!("Got error from HTTP request: {}", e);
+            return None;
+        }
+    };
+
+    trace!("Got HTTP {} from TL", response.status());
+    let bytes = response.bytes().await.unwrap();
+
+    // Try and parse torrent
+    trace!("Going to bencode-decode torrent");
+    let t = match de::from_bytes::<torrent::Torrent>(&bytes) {
+        Ok(t) => {
+            trace!("Parsed torrent, got {:?}", t);
+            t
+        },
+        Err(e) => {
+            error!("Error bencode-decoding torrent: {}", e);
+            return None;
+        }
+    };
+
+    return Some(TorrentleechTorrent{
+        name: name_dot,
+        uploader: msg[name_end_index+15..uploader_end_index].to_owned(),
+        url,
+        freeleech,
+        id,
+        raw_torrent: bytes.to_vec(),
+        // path: p.into(),
+        size: t.size(),
+    });
 }

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -85,9 +85,6 @@ impl super::Tracker for TorrentleechTracker {
         client.identify()?;
         let mut stream = client.stream()?;
         info!("Connected");
-        // let x = trackers::torrentleech::TorrentleechTracker{};
-        // let tl = trackers::torrentleech::TorrentleechTracker::new(&env::var("TL_RSS_KEY").unwrap());
-        // let f = filter.clone();
 
     
         while let Some(message) = stream.next().await.transpose()? {
@@ -102,12 +99,16 @@ impl super::Tracker for TorrentleechTracker {
                             debug!("Got new release: {:?}", x);
 
                             if filter.check(x) == true {
-
+                                debug!("Passed filter, we should get it");
+                            } else {
+                                debug!("Did not pass filter")
                             }
+                        } else {
+                            error!("Filed to parse message: {}", p2);
                         }
                     },
                     _ => {
-                        debug!("Got something we don't handle")
+                        // noop
                     }
                 }
             });


### PR DESCRIPTION
We want to handle the IRC message in a task, so that handling of a message does not block other messages from being handled.

This leads to some problems since `self` cannot be passed to the task: so we move `parse_message` to a pure function, clone `self.rss_key` and pass that.

Also, even though `filter` is basically a read only config thingy, we need to wrap it in `Arc` and `.clone()` it to be able to pass it.

Not sure if this is the best way, will ask some rust pros.