### PR TITLE
Tracker Config, leak to use references

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,6 @@ async fn main() -> Result<(), failure::Error> {
 
     let cfg: Box<Config> = Box::new(confy::load("snatcher", "snatcher").unwrap());
     let leaked_config = Box::leak(cfg);
-    let tl = trackers::torrentleech::TorrentleechTracker::new(&leaked_config.torrentleech);
-    let ipt = trackers::ipt::IptTracker::new(&leaked_config.ipt);
 
     let filter = Box::new(filters::Filter {
         valid_regexes: RegexSet::new(&leaked_config.valid_regexes).unwrap(),
@@ -54,15 +52,18 @@ async fn main() -> Result<(), failure::Error> {
     });
     let leaked_filter: &'static filters::Filter = Box::leak(filter);
 
+    let tl = trackers::torrentleech::TorrentleechTracker::new(&leaked_config.torrentleech);
+    let ipt = trackers::ipt::IptTracker::new(&leaked_config.ipt);
+
     let tl_t = tokio::spawn(async move {
-        tl.monitor(&leaked_filter).await;
+        tl.monitor(&leaked_filter).await
     });
     let ipt_t = tokio::spawn(async move {
-        ipt.monitor(&leaked_filter).await;
+        ipt.monitor(&leaked_filter).await
     });
 
-    // join!(tl_t, ipt_t);
-    join!(tl_t, ipt_t);
+    // We don't care about the result (should we?)
+    let _ = join!(tl_t, ipt_t);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), failure::Error> {
 
     let cfg: Box<Config> = Box::new(confy::load("snatcher", "snatcher").unwrap());
     let leaked_config = Box::leak(cfg);
-    let tl = trackers::torrentleech::TorrentleechTracker::new(&leaked_config.torrentleech.rss_key);
+    let tl = trackers::torrentleech::TorrentleechTracker::new(&leaked_config.torrentleech);
     let ipt = trackers::ipt::IptTracker::new(&leaked_config.ipt);
 
     let filter = Arc::new(filters::Filter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,14 @@ struct TorrentleechConfig {
 async fn main() -> Result<(), failure::Error> {
     env_logger::init();
 
-    let cfg: Config = confy::load("snatcher", "snatcher").unwrap();
-    let tl = trackers::torrentleech::TorrentleechTracker::new(&cfg.torrentleech.rss_key);
-    let ipt = trackers::ipt::IptTracker::new(&cfg.ipt.passkey);
+    let cfg: Box<Config> = Box::new(confy::load("snatcher", "snatcher").unwrap());
+    let leaked_config = Box::leak(cfg);
+    let tl = trackers::torrentleech::TorrentleechTracker::new(&leaked_config.torrentleech.rss_key);
+    let ipt = trackers::ipt::IptTracker::new(&leaked_config.ipt);
 
     let filter = Arc::new(filters::Filter {
-        valid_regexes: RegexSet::new(&cfg.valid_regexes).unwrap(),
-        size_max: cfg.max_size,
+        valid_regexes: RegexSet::new(&leaked_config.valid_regexes).unwrap(),
+        size_max: leaked_config.max_size,
     });
 
     // let tl_t = tokio::spawn(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,17 +19,33 @@ mod torrent;
 struct Config {
     valid_regexes: Vec<String>,
     max_size: i64,
+
+    // Per Tracker Configs
+    ipt: IptConfig,
+    torrentleech: TorrentleechConfig,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[serde(default)]
+struct IptConfig {
+    username: String,
+    passkey: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[serde(default)]
+struct TorrentleechConfig {
+    username: String,
+    rss_key: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), failure::Error> {
     env_logger::init();
-    // We can also load the Config at runtime via Config::load("path/to/config.toml")
 
     let cfg: Config = confy::load("snatcher", "snatcher").unwrap();
-
-    let tl = trackers::torrentleech::TorrentleechTracker::new(&env::var("TL_RSS_KEY").unwrap());
-    let ipt = trackers::ipt::IptTracker::new(&env::var("IPT_PASSKEY").unwrap());
+    let tl = trackers::torrentleech::TorrentleechTracker::new(&cfg.torrentleech.rss_key);
+    let ipt = trackers::ipt::IptTracker::new(&cfg.ipt.passkey);
 
     let filter = Arc::new(filters::Filter {
         valid_regexes: RegexSet::new(&cfg.valid_regexes).unwrap(),
@@ -40,7 +56,7 @@ async fn main() -> Result<(), failure::Error> {
     //     tl.monitor(&filter).await;
     // });
     let ipt_t = tokio::spawn(async move {
-        ipt.monitor(filter).await;
+        // ipt.monitor(filter).await;
     });
 
     // join!(tl_t, ipt_t);

--- a/src/trackers/ipt.rs
+++ b/src/trackers/ipt.rs
@@ -107,7 +107,7 @@ impl super::Tracker for IptTracker {
 
     async fn monitor(&self, filter: &'static filters::Filter) -> Result<(), failure::Error> {
         let config = Config {
-            nickname: Some("snatcherdev_bot".to_owned()),
+            nickname: Some(self.config.username.to_owned()),
             server: Some("irc.iptorrents.com".to_owned()),
             port: Some(6667),
             channels: vec!["#ipt.announce".to_owned()],

--- a/src/trackers/ipt.rs
+++ b/src/trackers/ipt.rs
@@ -105,7 +105,7 @@ impl super::Tracker for IptTracker {
         }
     }
 
-    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error> {
+    async fn monitor(&self, filter: &'static filters::Filter) -> Result<(), failure::Error> {
         let config = Config {
             nickname: Some("snatcherdev_bot".to_owned()),
             server: Some("irc.iptorrents.com".to_owned()),
@@ -123,7 +123,6 @@ impl super::Tracker for IptTracker {
 
         while let Some(message) = stream.next().await.transpose()? {
             let passkey = self.config.passkey.to_owned();
-            let filter = filter.clone();
             tokio::spawn(async move {
                 match message.command {
                     Command::PRIVMSG(_, p2) => {

--- a/src/trackers/mod.rs
+++ b/src/trackers/mod.rs
@@ -17,7 +17,7 @@ pub trait Torrent: std::fmt::Debug {
 pub trait Tracker {
     type Torrent: Torrent;
 
-    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error>;
+    async fn monitor(&self, filter: &'static filters::Filter) -> Result<(), failure::Error>;
     async fn parse_message(&self, msg: &str) -> Option<Self::Torrent>;
     async fn download(&self, torrent: Self::Torrent) -> Result<OsString, failure::Error>;
 }

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -78,7 +78,7 @@ impl super::Tracker for TorrentleechTracker {
         todo!()
     }
 
-    async fn monitor(&self, filter: Arc<filters::Filter>) -> Result<(), failure::Error> {
+    async fn monitor(&self, filter: &'static filters::Filter) -> Result<(), failure::Error> {
         let config = Config {
             nickname: Some("snatcherdev_bot".to_owned()),
             server: Some("irc.torrentleech.org".to_owned()),
@@ -95,7 +95,6 @@ impl super::Tracker for TorrentleechTracker {
 
         while let Some(message) = stream.next().await.transpose()? {
             let rss_key = self.config.rss_key.to_owned();
-            let filter = filter.clone();
 
             tokio::spawn(async move {
                 match message.command {

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -80,7 +80,7 @@ impl super::Tracker for TorrentleechTracker {
 
     async fn monitor(&self, filter: &'static filters::Filter) -> Result<(), failure::Error> {
         let config = Config {
-            nickname: Some("snatcherdev_bot".to_owned()),
+            nickname: Some(self.config.username.to_owned()),
             server: Some("irc.torrentleech.org".to_owned()),
             port: Some(7021),
             channels: vec!["#tlannounces".to_owned()],

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -13,16 +13,16 @@ use irc::{
 use log::{debug, error, info, trace};
 use serde_bencode::de;
 
-use crate::{action::add_to_qbit, filters, torrent, trackers::Torrent};
+use crate::{action::add_to_qbit, filters, torrent, trackers::Torrent, TorrentleechConfig};
 
 pub struct TorrentleechTracker {
-    rss_key: String,
+    config: &'static TorrentleechConfig
 }
 
 impl TorrentleechTracker {
-    pub fn new(rss_key: &str) -> Self {
+    pub fn new(config: &'static TorrentleechConfig) -> Self {
         TorrentleechTracker {
-            rss_key: rss_key.to_owned(),
+            config,
         }
     }
 }
@@ -94,7 +94,7 @@ impl super::Tracker for TorrentleechTracker {
         info!("Connected");
 
         while let Some(message) = stream.next().await.transpose()? {
-            let rss_key = self.rss_key.to_owned();
+            let rss_key = self.config.rss_key.to_owned();
             let filter = filter.clone();
 
             tokio::spawn(async move {


### PR DESCRIPTION
Per tracker config start. Still need to make matches tracker specific

Use Box::leak to leak the config so we can pass `&'static` down to the guys who need it instead of cloning: https://users.rust-lang.org/t/efficient-way-to-pass-read-only-shared-state-to-tokio-spawn/114224/2?u=ckcr4lyf