### PR TITLE
Kill OOP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,13 +54,10 @@ async fn main() -> Result<(), failure::Error> {
 
     debug!("Got config as {:?}", &leaked_config);
 
-    let tl_t = tokio::spawn(async move {
-        torrentleech::monitor(&leaked_config.torrentleech).await
-    });
-    
-    let ipt_t = tokio::spawn(async move {
-        ipt_monitor(&leaked_config.ipt).await
-    });
+    let tl_t =
+        tokio::spawn(async move { torrentleech::monitor(&leaked_config.torrentleech).await });
+
+    let ipt_t = tokio::spawn(async move { ipt_monitor(&leaked_config.ipt).await });
 
     // We don't care about the result (should we?)
     let _ = join!(tl_t, ipt_t);

--- a/src/trackers/ipt.rs
+++ b/src/trackers/ipt.rs
@@ -44,7 +44,6 @@ impl super::Torrent for IptTorrent {
     }
 }
 
-
 async fn parse_message(msg: &str) -> Option<IptTorrent> {
     trace!("parse_message for {} ({:2X?})", msg, msg.as_bytes());
 

--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -13,7 +13,12 @@ use irc::{
 use log::{debug, error, info, trace};
 use serde_bencode::de;
 
-use crate::{action::{add_to_qbit, add_to_qbit_v2}, filters, torrent, trackers::Torrent, TorrentleechConfig};
+use crate::{
+    action::{add_to_qbit, add_to_qbit_v2},
+    filters, torrent,
+    trackers::Torrent,
+    TorrentleechConfig,
+};
 
 #[derive(Debug)]
 pub struct TorrentleechTorrent {
@@ -138,7 +143,7 @@ pub async fn monitor(tracker_config: &'static TorrentleechConfig) -> Result<(), 
     let mut stream = client.stream()?;
     info!("Connected");
 
-    let filter: &'static filters::Filter = Box::leak(Box::new(filters::Filter{
+    let filter: &'static filters::Filter = Box::leak(Box::new(filters::Filter {
         valid_regexes: regex::RegexSet::new(&tracker_config.filter.valid_regexes).unwrap(),
         size_max: tracker_config.filter.max_size,
     }));


### PR DESCRIPTION
Remove the enforced restrictions around the tracker structs, and them implementing monitor.

Better implemented as a pure function, don't need to worry about self cloning / lifetime, just leak config (XD).