### PR TITLE
Make monitor a wrapper fn (kinda DRY)

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,6 +1,6 @@
 // TODO: maybe trait?
 
-use std::ffi::OsStr;
+use std::{ffi::OsStr, thread::JoinHandle, u16};
 
 use log::{debug, error, info, trace};
 
@@ -50,3 +50,9 @@ pub fn add_to_qbit_v2(path: &OsStr) {
         }
     }
 }
+
+
+// train MonitorFn {
+//     fn
+// }
+

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,6 +1,6 @@
 // TODO: maybe trait?
 
-use std::{ffi::OsStr, thread::JoinHandle, u16};
+use std::ffi::OsStr;
 
 use log::{debug, error, info, trace};
 
@@ -50,9 +50,3 @@ pub fn add_to_qbit_v2(path: &OsStr) {
         }
     }
 }
-
-
-// train MonitorFn {
-//     fn
-// }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,5 +110,22 @@ async fn main() -> Result<(), failure::Error> {
     let (torrentleech_join_result, ipt_join_result) = join!(tl_t, ipt_t);
     error!("We joined the threads, something went wrong!\nTorrentleech: {:?}\nIPT: {:?}", torrentleech_join_result, ipt_join_result);
 
+    monitor(yolo, 1).await;
+
     Ok(())
+}
+
+async fn monitor<T>(monitor_fn: (impl Fn () -> (Result<(), failure::Error>) + Send + Sync + 'static), config: T) -> tokio::task::JoinHandle<Result<(), failure::Error>> {
+    tokio::spawn(async move {
+        loop {
+            info!("[]] going to connect (monitor in loop...");
+            monitor_fn();
+            return Ok(())
+        }
+    })
+}
+
+
+fn yolo() -> Result<(), Error> {
+    return Ok(())
 }


### PR DESCRIPTION
* Each monitor fn takes different config type
* But the actual logic is basically the same (error handling, loop etc)