### PR TITLE
Dont wrap tokio spawn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ async fn main() -> Result<(), failure::Error> {
 
     debug!("Got config as {:?}", &leaked_config);
 
-    let tl_t = monitor_wrapper(torrentleech::monitor, &leaked_config.torrentleech, "torrentleech");
-    let ipt_t = monitor_wrapper(ipt::ipt_monitor, &leaked_config.ipt, "iptorrents");
+    let tl_t = tokio::spawn(async {monitor_wrapper(torrentleech::monitor, &leaked_config.torrentleech, "torrentleech").await});
+    let ipt_t = tokio::spawn(async {monitor_wrapper(ipt::ipt_monitor, &leaked_config.ipt, "iptorrents").await});
 
     // We don't care about the result (should we?)
     let (torrentleech_join_result, ipt_join_result) = join!(tl_t, ipt_t);
@@ -65,36 +65,34 @@ async fn main() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn monitor_wrapper<F, Fut, T: Sync>(monitor_fn: F, config: &'static T, tracker_name: &'static str) -> tokio::task::JoinHandle<Result<(), failure::Error>> 
+async fn monitor_wrapper<F, Fut, T>(monitor_fn: F, config: &'static T, tracker_name: &'static str) -> Result<(), failure::Error>
 where 
-    F: Fn(&'static T) -> Fut + Send + 'static,
-    Fut: Future<Output = Result<(), failure::Error>> + Send
+    F: Fn(&'static T) -> Fut,
+    Fut: Future<Output = Result<(), failure::Error>>
 {
-    tokio::spawn(async move {
-        loop {
-            info!("[{}] going to connect (monitor) in loop...", tracker_name);
-            match monitor_fn(config).await {
-                Ok(_) => {
-                    error!("monitor resolved w/ Ok(), should be impossible!");
+    loop {
+        info!("[{}] going to connect (monitor) in loop...", tracker_name);
+        match monitor_fn(config).await {
+            Ok(_) => {
+                error!("monitor resolved w/ Ok(), should be impossible!");
+                // we will sleep for 60s and then reconnect
+                tokio::time::sleep(Duration::from_millis(60000)).await;
+            },
+            Err(e) => match e.downcast_ref::<irc::error::Error>() {
+                Some(irc::error::Error::PingTimeout) => {
+                    error!("got a ping timeout! will try and reconnect")
+                },
+                Some(other) => {
+                    error!("Got some other IRC error: {:?}", other);
                     // we will sleep for 60s and then reconnect
                     tokio::time::sleep(Duration::from_millis(60000)).await;
-                },
-                Err(e) => match e.downcast_ref::<irc::error::Error>() {
-                    Some(irc::error::Error::PingTimeout) => {
-                        error!("got a ping timeout! will try and reconnect")
-                    },
-                    Some(other) => {
-                        error!("Got some other IRC error: {:?}", other);
-                        // we will sleep for 60s and then reconnect
-                        tokio::time::sleep(Duration::from_millis(60000)).await;
-                    }
-                    None => {
-                        error!("Got non-irc error: {:?}", e);
-                        // we will sleep for 60s and then reconnect
-                        tokio::time::sleep(Duration::from_millis(60000)).await;
-                    }
-                },
-            }
+                }
+                None => {
+                    error!("Got non-irc error: {:?}", e);
+                    // we will sleep for 60s and then reconnect
+                    tokio::time::sleep(Duration::from_millis(60000)).await;
+                }
+            },
         }
-    })
+    }
 }


### PR DESCRIPTION
At least we can remove the `T: Sync`, `+ Sync`,  and return signature is a bit cleaner