### PR TITLE
Check Result of Output

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -39,11 +39,15 @@ pub fn add_to_qbit_v2(path: &OsStr) {
         .output()
     {
         Ok(output) => {
-            info!("Added {:?} to qbittorrent", path);
-            debug!(
-                "Added to qbittorrent: {}",
-                String::from_utf8_lossy(&output.stdout)
-            );
+            if output.status.success() {
+                info!("Added {:?} to qbittorrent", path);
+                debug!(
+                    "Added to qbittorrent: {}",
+                    String::from_utf8_lossy(&output.stdout)
+                );
+            } else {
+                error!("Failed to add. Program return non-zero exit status: {:?}\nstderr: {}", output.status.code(), String::from_utf8_lossy(&output.stderr));
+            }
         }
         Err(e) => {
             error!("Failed to add: {}", e);

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,32 +1,7 @@
 // TODO: maybe trait?
 
 use std::ffi::OsStr;
-
 use log::{debug, error, info, trace};
-
-use crate::trackers;
-
-pub fn add_to_qbit(torrent: impl trackers::Torrent) {
-    trace!("Going to add {}", torrent.name());
-
-    // Assume qbit-race.
-    // mix args and arg so we can pass str and OsStr
-    match std::process::Command::new("qbit-race")
-        .args(["add", "-p"])
-        .arg(torrent.path())
-        .output()
-    {
-        Ok(output) => {
-            debug!(
-                "Added to qbittorrent: {}",
-                String::from_utf8_lossy(&output.stdout)
-            );
-        }
-        Err(e) => {
-            error!("Failed to add: {}", e);
-        }
-    }
-}
 
 pub fn add_to_qbit_v2(path: &OsStr) {
     trace!("Going to add {:?}", path);


### PR DESCRIPTION
The generic `Result` that is returned is not enough, even if the command fails output is `Ok()` , we need to check the exit-code to determine success vs. failure.

See: https://github.com/rust-lang/rfcs/pull/3362