### PR TITLE
Remove hash from URL, handle 404

### DIFF
--- a/src/trackers/torrentleech.rs
+++ b/src/trackers/torrentleech.rs
@@ -51,6 +51,7 @@ enum TorrentleechError {
     BencodeError,
     FilesystemError,
     ParseError,
+    TorrentNotFound,
 }
 
 async fn parse_message(rss_key: &str, msg: &str) -> Result<TorrentleechTorrent, TorrentleechError> {
@@ -78,6 +79,11 @@ async fn parse_message(rss_key: &str, msg: &str) -> Result<TorrentleechTorrent, 
     };
 
     trace!("Got HTTP {} from TL", response.status());
+    // If HTTP 404, then we don't have the torrent...
+    if response.status() == 404 {
+        return Err(TorrentleechError::TorrentNotFound);
+    }
+
     let bytes = match response.bytes().await {
         Ok(v) => v,
         Err(e) => {
@@ -208,7 +214,7 @@ fn parse_fields_from_msg(msg: &str) -> Option<MessagedParsedFields> {
     };
 
     let name_original: String = msg[name_start_index + 6..name_end_index].to_owned();
-    let name_dot = name_original.replace(" ", ".");
+    let name_dot = name_original.replace(" ", ".").replace("#", ""); // Replace space w/ '.' , remove '#' (TBD if more rules for TL)
     let url: String = msg[uploader_end_index + lenn..].to_owned();
 
     let id_index = url.rfind("/")?;


### PR DESCRIPTION
Fixes:

<img width="2181" height="147" alt="image" src="https://github.com/user-attachments/assets/3b161a6c-7502-4a46-b287-d113ed0d03fe" />

* From TL it seems the hash should not be part of the URL (obviously...)
* If we get a HTTP 404, do not try and bencode-decode the torrent (since its probably HTML, not a .torrent file)